### PR TITLE
Fix: Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
-cffi>=0.9.2
+cffi>=0.9.2,<0.10
 Flask==0.11.1
 Flask-Bootstrap>=3.3.2.1,<4.0
 Flask-Cors==2.1.2
-pycparser>=2.10
-pyalsaaudio>=0.8
-gevent>=1.0.1
-pylast>=1.6.0
+pycparser>=2.10,<2.11
+pyalsaaudio>=0.8,<0.9
+gevent==1.0.1
+pylast==1.6.0
+werkzeug<1.0
+Jinja2>=2.4,<2.5
+itsdangerous>=0.21,<0.22
+click>=2.0,<2.1


### PR DESCRIPTION
Most of the dependencies are breaking, and hence it is necessary to define limit their versions to a certain maximum version in `requirements.txt`.