### PR TITLE
Fix (dependencies): Fix requirements.txt missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyalsaaudio>=0.8,<0.9
 gevent==1.0.1
 pylast==1.6.0
 werkzeug<1.0
-Jinja2>=2.4,<2.5
+Jinja2>=2.7,<3.0
 itsdangerous>=0.21,<0.22
 click>=2.0,<2.1


### PR DESCRIPTION
Fixes #12
    
- `Jinja2>=2.7,<3.0` ( Flask `0.11.1`  dependency). Flask `0.11.1` does not declare `markupsafe` as an explicit dependency but assumes that its `Jinja2` dependency declares `markupsafe` as a dependency. Only since `Jinja2>=2.7` is `markupsafe` defined as an explicit dependency. Hence we add  that to requirements.txt.
    
- `itsdangerous>=0.21,<0.22` ( Flask `0.11.1`  dependency) limited to its minor version
    
- `click>=2.0,<2.1` ( Flask `0.11.1`  dependency) limited to its minor version

See: https://github.com/pallets/flask/blob/d1d82ca8ce7262ad9d27245ce44f86571287810e/setup.py#L71-L75