### PR TITLE
Fix (dependencies): Lock markupsafe to 1.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ werkzeug<1.0
 Jinja2>=2.7,<3.0
 itsdangerous>=0.21,<0.22
 click>=2.0,<2.1
+markupsafe==1.0


### PR DESCRIPTION

Fixes #12

Despite fixes in #13, Flask `0.11.1` resolves `markupsafe` dependency to a breaking version `2.x`. This change locks the version of `markupsafe==1.0`.